### PR TITLE
Remove parkour component from character

### DIFF
--- a/Source/Shooter/Private/Player/ShooterCharacter.cpp
+++ b/Source/Shooter/Private/Player/ShooterCharacter.cpp
@@ -13,7 +13,6 @@
 #include "Inventory/InventoryComponent.h"
 #include "Kismet/GameplayStatics.h"
 #include "Net/UnrealNetwork.h"
-#include "Player/ParkourMovementComponent.h"
 #include "Player/ShooterPlayerController.h"
 #include "Weapon/WeaponBase.h"
 
@@ -75,7 +74,6 @@ AShooterCharacter::AShooterCharacter()
 	TPSpringArmComponent->SocketOffset = FVector(0, 50, 50);
 	TPSpringArmComponent->SetRelativeLocation(FVector(0, 0, 96));
 
-	ParkourMovementComponent = CreateDefaultSubobject<UParkourMovementComponent>(TEXT("Parkour Movement"));
 
 	GetCharacterMovement()->MaxWalkSpeed = 1200.0f;
 	GetCharacterMovement()->GravityScale = 2.0f;

--- a/Source/Shooter/Private/Player/ShooterCharacter.cpp
+++ b/Source/Shooter/Private/Player/ShooterCharacter.cpp
@@ -16,6 +16,7 @@
 #include "Player/ShooterPlayerController.h"
 #include "Weapon/WeaponBase.h"
 
+// Sets default values
 AShooterCharacter::AShooterCharacter()
 {
 	PrimaryActorTick.bCanEverTick = true;
@@ -85,14 +86,16 @@ AShooterCharacter::AShooterCharacter()
 void AShooterCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
-	DOREPLIFETIME(AShooterCharacter, WeaponActor);
-	DOREPLIFETIME(AShooterCharacter, AimOffsetYaw);
-	DOREPLIFETIME(AShooterCharacter, AimOffsetPitch);
+        DOREPLIFETIME(AShooterCharacter, WeaponActor);
+        DOREPLIFETIME(AShooterCharacter, AimOffsetYaw);
+        DOREPLIFETIME(AShooterCharacter, AimOffsetPitch);
+        DOREPLIFETIME(AShooterCharacter, ViewMode);
 }
 
+// Called when the game starts
 void AShooterCharacter::BeginPlay()
 {
-	Super::BeginPlay();
+        Super::BeginPlay();
 
 	// Bind On Weapon Equipped Delegate & Equip first weapon
 	if (InventoryComponent)
@@ -111,9 +114,10 @@ void AShooterCharacter::BeginPlay()
     SetPlayerViewMode(InitialView);
 }
 
+// Called every frame
 void AShooterCharacter::Tick(float DeltaTime)
 {
-	Super::Tick(DeltaTime);
+        Super::Tick(DeltaTime);
 
 	if (HasAuthority())
 	{
@@ -231,27 +235,42 @@ int32 AShooterCharacter::RequestAmmo_Implementation(FGameplayTag AmmoType, int32
 
 void AShooterCharacter::SetPlayerViewMode(EPlayerViewMode NewViewMode)
 {
-	if (!CameraComponent)
-	{
-		LOG_ERROR("Cannot change view mode, CameraComponent is invalid");
-		return;
-	}
-	
-    // Remote players and AI should always display as third person
-    ViewMode = IsLocallyControlled() ? NewViewMode : EPlayerViewMode::ThirdPerson;
+        if (ViewMode == NewViewMode)
+        {
+                return;
+        }
 
-	switch (ViewMode)
-	{
+        if (!HasAuthority())
+        {
+                ServerSetPlayerViewMode(NewViewMode);
+        }
+
+        // Remote players and AI always remain in third person
+        ViewMode = IsLocallyControlled() ? NewViewMode : EPlayerViewMode::ThirdPerson;
+
+        ApplyViewMode();
+}
+
+void AShooterCharacter::ApplyViewMode()
+{
+        if (!CameraComponent)
+        {
+                LOG_ERROR("Cannot change view mode, CameraComponent is invalid");
+                return;
+        }
+
+        switch (ViewMode)
+        {
         case EPlayerViewMode::FirstPerson:
                 FPMesh->SetOnlyOwnerSee(true);
                 FPMesh->SetOwnerNoSee(false);
                 FPMesh->SetHiddenInGame(false, true);
                 GetMesh()->SetOnlyOwnerSee(false);
                 GetMesh()->SetOwnerNoSee(true);
-               CameraSkeletalMesh->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
-               CameraSkeletalMesh->AttachToComponent(FPCameraRootSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
-               CameraSkeletalMesh->SetRelativeLocation(FVector::ZeroVector);
-               CameraSkeletalMesh->SetRelativeRotation(FRotator::ZeroRotator);
+                CameraSkeletalMesh->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
+                CameraSkeletalMesh->AttachToComponent(FPCameraRootSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
+                CameraSkeletalMesh->SetRelativeLocation(FVector::ZeroVector);
+                CameraSkeletalMesh->SetRelativeRotation(FRotator::ZeroRotator);
                 bUseControllerRotationYaw = true;
                 bUseControllerRotationRoll = false;
                 break;
@@ -261,10 +280,10 @@ void AShooterCharacter::SetPlayerViewMode(EPlayerViewMode NewViewMode)
                 FPMesh->SetHiddenInGame(true, true);
                 GetMesh()->SetOnlyOwnerSee(false);
                 GetMesh()->SetOwnerNoSee(false);
-               CameraSkeletalMesh->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
-               CameraSkeletalMesh->AttachToComponent(TPSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
-               CameraSkeletalMesh->SetRelativeLocation(FVector::ZeroVector);
-               CameraSkeletalMesh->SetRelativeRotation(FRotator::ZeroRotator);
+                CameraSkeletalMesh->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
+                CameraSkeletalMesh->AttachToComponent(TPSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
+                CameraSkeletalMesh->SetRelativeLocation(FVector::ZeroVector);
+                CameraSkeletalMesh->SetRelativeRotation(FRotator::ZeroRotator);
                 bUseControllerRotationYaw = true;
                 bUseControllerRotationRoll = false;
                 break;
@@ -391,4 +410,14 @@ void AShooterCharacter::HandleCharacterDeath_Implementation(AController* Instiga
                         }, 0.02f, true); // runs every frame (50 FPS)
                 }, 0.3f, false);
         }
+}
+
+void AShooterCharacter::ServerSetPlayerViewMode_Implementation(EPlayerViewMode NewViewMode)
+{
+        SetPlayerViewMode(NewViewMode);
+}
+
+void AShooterCharacter::OnRep_ViewMode()
+{
+        ApplyViewMode();
 }

--- a/Source/Shooter/Private/Player/ShooterCharacter.cpp
+++ b/Source/Shooter/Private/Player/ShooterCharacter.cpp
@@ -34,19 +34,13 @@ AShooterCharacter::AShooterCharacter()
 	GetMesh()->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 	GetMesh()->SetCollisionResponseToChannel(ECC_Visibility, ECR_Block);
 
-	FPRootSceneComponent = CreateDefaultSubobject<USceneComponent>(TEXT("FP_Root"));
-	FPRootSceneComponent->SetupAttachment(RootComponent);
+       FPMeshRootSpringArmComponent = CreateDefaultSubobject<USpringArmComponent>(TEXT("Mesh_Root"));
+       FPMeshRootSpringArmComponent->SetupAttachment(RootComponent);
+       FPMeshRootSpringArmComponent->bUsePawnControlRotation = true;
 
-	FPMeshRootSpringArmComponent = CreateDefaultSubobject<USpringArmComponent>(TEXT("Mesh_Root"));
-	FPMeshRootSpringArmComponent->SetupAttachment(FPRootSceneComponent);
-	FPMeshRootSpringArmComponent->bUsePawnControlRotation = true;
-
-	OffsetRootSceneComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Offset_Root"));
-	OffsetRootSceneComponent->SetupAttachment(FPMeshRootSpringArmComponent);
-
-	FPMesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("FirstPersonMesh"));
-	FPMesh->SetupAttachment(OffsetRootSceneComponent);
-	FPMesh->SetRelativeLocation(FVector(0, 0, -96));
+       FPMesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("FirstPersonMesh"));
+       FPMesh->SetupAttachment(FPMeshRootSpringArmComponent);
+       FPMesh->SetRelativeLocation(FVector(0, 0, -96));
 	FPMesh->SetOnlyOwnerSee(true);
 	FPMesh->SetOwnerNoSee(false);
 	FPMesh->SetCastShadow(false);
@@ -56,9 +50,9 @@ AShooterCharacter::AShooterCharacter()
 	FPMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 	FPMesh->SetCollisionResponseToAllChannels(ECR_Ignore);
 
-	FPCameraRootSpringArmComponent = CreateDefaultSubobject<USpringArmComponent>(TEXT("Camera_Root"));
-	FPCameraRootSpringArmComponent->SetupAttachment(FPRootSceneComponent);
-	FPCameraRootSpringArmComponent->bUsePawnControlRotation = true;
+       FPCameraRootSpringArmComponent = CreateDefaultSubobject<USpringArmComponent>(TEXT("Camera_Root"));
+       FPCameraRootSpringArmComponent->SetupAttachment(RootComponent);
+       FPCameraRootSpringArmComponent->bUsePawnControlRotation = true;
 
 	CameraSkeletalMesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("Camera_SkeletalMesh"));
 	CameraSkeletalMesh->SetupAttachment(FPCameraRootSpringArmComponent);
@@ -254,10 +248,10 @@ void AShooterCharacter::SetPlayerViewMode(EPlayerViewMode NewViewMode)
                 FPMesh->SetHiddenInGame(false, true);
                 GetMesh()->SetOnlyOwnerSee(false);
                 GetMesh()->SetOwnerNoSee(true);
-                CameraComponent->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
-                CameraComponent->AttachToComponent(CameraSkeletalMesh, FAttachmentTransformRules::KeepRelativeTransform);
-                CameraComponent->SetRelativeLocation(FVector::ZeroVector);
-                CameraComponent->SetRelativeRotation(FRotator::ZeroRotator);
+               CameraSkeletalMesh->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
+               CameraSkeletalMesh->AttachToComponent(FPCameraRootSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
+               CameraSkeletalMesh->SetRelativeLocation(FVector::ZeroVector);
+               CameraSkeletalMesh->SetRelativeRotation(FRotator::ZeroRotator);
                 bUseControllerRotationYaw = true;
                 bUseControllerRotationRoll = false;
                 break;
@@ -267,10 +261,10 @@ void AShooterCharacter::SetPlayerViewMode(EPlayerViewMode NewViewMode)
                 FPMesh->SetHiddenInGame(true, true);
                 GetMesh()->SetOnlyOwnerSee(false);
                 GetMesh()->SetOwnerNoSee(false);
-                CameraComponent->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
-                CameraComponent->AttachToComponent(TPSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
-                CameraComponent->SetRelativeLocation(FVector::ZeroVector);
-                CameraComponent->SetRelativeRotation(FRotator::ZeroRotator);
+               CameraSkeletalMesh->DetachFromComponent(FDetachmentTransformRules::KeepWorldTransform);
+               CameraSkeletalMesh->AttachToComponent(TPSpringArmComponent, FAttachmentTransformRules::KeepRelativeTransform);
+               CameraSkeletalMesh->SetRelativeLocation(FVector::ZeroVector);
+               CameraSkeletalMesh->SetRelativeRotation(FRotator::ZeroRotator);
                 bUseControllerRotationYaw = true;
                 bUseControllerRotationRoll = false;
                 break;

--- a/Source/Shooter/Private/Player/ShooterCharacter.cpp
+++ b/Source/Shooter/Private/Player/ShooterCharacter.cpp
@@ -1,4 +1,7 @@
 #include "Player/ShooterCharacter.h"
+
+// Implements the primary character used by the player. Handles weapon logic,
+// camera switching and death behaviour.
 #include "Animation/AnimInstance.h"
 #include "Camera/CameraActor.h"
 #include "Camera/CameraComponent.h"
@@ -16,7 +19,7 @@
 #include "Player/ShooterPlayerController.h"
 #include "Weapon/WeaponBase.h"
 
-// Sets default values
+// Sets default values for this character's properties
 AShooterCharacter::AShooterCharacter()
 {
 	PrimaryActorTick.bCanEverTick = true;
@@ -83,6 +86,7 @@ AShooterCharacter::AShooterCharacter()
 	WeaponSocketName = TEXT("WeaponPoint");
 }
 
+// Register all replicated properties for this class
 void AShooterCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
@@ -92,7 +96,7 @@ void AShooterCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& Ou
         DOREPLIFETIME(AShooterCharacter, ViewMode);
 }
 
-// Called when the game starts
+// Called when the game starts or when spawned
 void AShooterCharacter::BeginPlay()
 {
         Super::BeginPlay();
@@ -114,7 +118,7 @@ void AShooterCharacter::BeginPlay()
     SetPlayerViewMode(InitialView);
 }
 
-// Called every frame
+// Update per-frame state and animations
 void AShooterCharacter::Tick(float DeltaTime)
 {
         Super::Tick(DeltaTime);
@@ -129,6 +133,7 @@ void AShooterCharacter::Tick(float DeltaTime)
 	}
 }
 
+// Called when a new weapon is equipped
 void AShooterCharacter::OnWeaponEquipped(float EquipCooldownDuration)
 {
 	if (!IsValid(InventoryComponent) || !InventoryComponent->GetEquippedWeapon())
@@ -160,6 +165,7 @@ void AShooterCharacter::OnWeaponEquipped(float EquipCooldownDuration)
 	SetPlayerViewMode(ViewMode);
 }
 
+// Instantly kills this character via damage application
 void AShooterCharacter::Kill()
 {
 	UGameplayStatics::ApplyDamage(
@@ -171,6 +177,7 @@ void AShooterCharacter::Kill()
 	);
 }
 
+// Triggers the equipped weapon to start firing
 void AShooterCharacter::BeginFire()
 {
 	if (!IsValid(InventoryComponent) || !IsValid(WeaponActor))
@@ -188,6 +195,7 @@ void AShooterCharacter::BeginFire()
 	}
 }
 
+// Stops the current firing sequence
 void AShooterCharacter::EndFire()
 {
 	if (WeaponActor)
@@ -196,6 +204,7 @@ void AShooterCharacter::EndFire()
 	}
 }
 
+// Attempts to reload the current weapon if ammo is available
 void AShooterCharacter::ReloadWeapon()
 {
 	if (!IsValid(InventoryComponent))
@@ -214,6 +223,7 @@ void AShooterCharacter::ReloadWeapon()
 	}
 }
 
+// IAmmoProvider interface - supplies ammo to other weapons
 int32 AShooterCharacter::RequestAmmo_Implementation(FGameplayTag AmmoType, int32 RequestedAmount)
 {
 	if (!InventoryComponent)
@@ -233,6 +243,7 @@ int32 AShooterCharacter::RequestAmmo_Implementation(FGameplayTag AmmoType, int32
 	return Provided;
 }
 
+// Switch between first and third person camera modes
 void AShooterCharacter::SetPlayerViewMode(EPlayerViewMode NewViewMode)
 {
         if (ViewMode == NewViewMode)
@@ -251,6 +262,7 @@ void AShooterCharacter::SetPlayerViewMode(EPlayerViewMode NewViewMode)
         ApplyViewMode();
 }
 
+// Applies the current view mode locally
 void AShooterCharacter::ApplyViewMode()
 {
         if (!CameraComponent)
@@ -298,6 +310,7 @@ void AShooterCharacter::ApplyViewMode()
         }
 }
 
+// Attaches the weapon meshes to the appropriate character meshes
 void AShooterCharacter::AttachWeaponToMesh()
 {
 	if (!IsValid(WeaponActor))
@@ -317,6 +330,7 @@ void AShooterCharacter::AttachWeaponToMesh()
 	WeaponActor->GetTPWeaponMeshComponent()->SetRelativeLocation(WeaponActor->GetWeaponOffset());
 }
 
+// Plays the equip animation montage either forwards or backwards
 void AShooterCharacter::PlayEquipMontage(const bool bReverse)
 {
 	if (!EquipMontage)
@@ -334,6 +348,7 @@ void AShooterCharacter::PlayEquipMontage(const bool bReverse)
 	}
 }
 
+// Replication callback for WeaponActor
 void AShooterCharacter::OnRep_WeaponActor()
 {
         AttachWeaponToMesh();
@@ -343,6 +358,7 @@ void AShooterCharacter::OnRep_WeaponActor()
         }
 }
 
+// Handles logic for when the character dies
 void AShooterCharacter::HandleCharacterDeath_Implementation(AController* InstigatedBy, AActor* DamageCauser)
 {
 	// Remove and destroy weapon
@@ -379,7 +395,10 @@ void AShooterCharacter::HandleCharacterDeath_Implementation(AController* Instiga
                 FTimerHandle CameraTimerHandle;
                 GetWorldTimerManager().SetTimer(CameraTimerHandle, [this, PC]()
                 {
-                        if (!PC) return;
+                        if (!PC)
+                        {
+                                return;
+                        }
 
                         // Spawn a camera actor behind and above the character
                         const FVector Offset = FVector(-300, 0, 150);
@@ -391,7 +410,10 @@ void AShooterCharacter::HandleCharacterDeath_Implementation(AController* Instiga
 
                         ACameraActor* TrackingCamera = GetWorld()->SpawnActor<ACameraActor>(
                                 InitialLocation, InitialRotation, SpawnParams);
-                        if (!TrackingCamera) return;
+                        if (!TrackingCamera)
+                        {
+                                return;
+                        }
 
                         PC->SetViewTargetWithBlend(TrackingCamera, 1.0f);
 
@@ -399,7 +421,10 @@ void AShooterCharacter::HandleCharacterDeath_Implementation(AController* Instiga
                         FTimerHandle FollowTimerHandle;
                         GetWorldTimerManager().SetTimer(FollowTimerHandle, [this, TrackingCamera]()
                         {
-                                if (!IsValid(this) || !IsValid(TrackingCamera)) return;
+                                if (!IsValid(this) || !IsValid(TrackingCamera))
+                                {
+                                        return;
+                                }
 
                                 const FVector FocusPoint = GetMesh()->GetComponentLocation();
                                 const FVector CamLocation = FocusPoint + FVector(-300, 0, 150);
@@ -412,11 +437,13 @@ void AShooterCharacter::HandleCharacterDeath_Implementation(AController* Instiga
         }
 }
 
+// Server RPC for view mode switching
 void AShooterCharacter::ServerSetPlayerViewMode_Implementation(EPlayerViewMode NewViewMode)
 {
         SetPlayerViewMode(NewViewMode);
 }
 
+// Called on clients when ViewMode is updated
 void AShooterCharacter::OnRep_ViewMode()
 {
         ApplyViewMode();

--- a/Source/Shooter/Public/Player/ShooterCharacter.h
+++ b/Source/Shooter/Public/Player/ShooterCharacter.h
@@ -1,5 +1,10 @@
 // ShooterCharacter.h
 
+/**
+ * Player controlled character used in Shooter. Handles weapon management,
+ * first/third person camera switching and replication of relevant state.
+ */
+
 #pragma once
 
 #include "CoreMinimal.h"
@@ -9,6 +14,7 @@
 #include "ShooterCharacter.generated.h"
 
 
+// Possible camera perspectives for the player
 UENUM(BlueprintType)
 enum class EPlayerViewMode : uint8
 {
@@ -32,9 +38,12 @@ class SHOOTER_API AShooterCharacter : public ACharacter, public IAmmoProvider
         GENERATED_BODY()
 
 public:
-	AShooterCharacter();
+        AShooterCharacter();
 
 protected:
+       // --------------------------------------------------------------------
+       // Components
+       // --------------------------------------------------------------------
        /** Spring arm used to position the first person mesh */
        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
        USpringArmComponent* FPMeshRootSpringArmComponent;
@@ -69,6 +78,9 @@ protected:
 
 
 protected:
+       // --------------------------------------------------------------------
+       // Configuration
+       // --------------------------------------------------------------------
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Shooter Character|Weapon")
 	FName WeaponSocketName;
 	
@@ -84,8 +96,11 @@ protected:
 	
 
 private:
-	UPROPERTY(Replicated)
-	float AimOffsetYaw;
+       // --------------------------------------------------------------------
+       // Replicated state
+       // --------------------------------------------------------------------
+       UPROPERTY(Replicated)
+       float AimOffsetYaw;
 
 	UPROPERTY(Replicated)
 	float AimOffsetPitch;
@@ -98,8 +113,8 @@ public:
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
 protected:
-	virtual void BeginPlay() override;
-	virtual void Tick(float DeltaTime) override;
+       virtual void BeginPlay() override;
+       virtual void Tick(float DeltaTime) override;
 
 public:
 	//virtual void Jump() override;
@@ -130,20 +145,22 @@ public:
        void SetPlayerViewMode(EPlayerViewMode NewViewMode);
 
 private:
-       /** Applies the current view mode locally */
+       /** Applies the current view mode locally on this instance */
        void ApplyViewMode();
 
        UFUNCTION(Server, Reliable)
        void ServerSetPlayerViewMode(EPlayerViewMode NewViewMode);
 
        UFUNCTION()
+       /** Called when ViewMode is replicated */
        void OnRep_ViewMode();
 
        void AttachWeaponToMesh();
        void PlayEquipMontage(bool bReverse);
 
-	UFUNCTION()
-	void OnRep_WeaponActor();
+       UFUNCTION()
+        /** Called when the equipped weapon changes */
+        void OnRep_WeaponActor();
 
        UFUNCTION(NetMulticast, Reliable)
        void HandleCharacterDeath(AController* InstigatedBy, AActor* DamageCauser);

--- a/Source/Shooter/Public/Player/ShooterCharacter.h
+++ b/Source/Shooter/Public/Player/ShooterCharacter.h
@@ -8,7 +8,6 @@
 #include "Weapon/AmmoProvider.h"
 #include "ShooterCharacter.generated.h"
 
-class UParkourMovementComponent;
 
 UENUM(BlueprintType)
 enum class EPlayerViewMode : uint8
@@ -65,8 +64,6 @@ protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Shooter Character|Components")
 	UInventoryComponent* InventoryComponent;
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Shooter Character|Components")
-	UParkourMovementComponent* ParkourMovementComponent;
 
 protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Shooter Character|Weapon")

--- a/Source/Shooter/Public/Player/ShooterCharacter.h
+++ b/Source/Shooter/Public/Player/ShooterCharacter.h
@@ -34,35 +34,29 @@ public:
 	AShooterCharacter();
 
 protected:
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|FP Components")
-	USceneComponent* FPRootSceneComponent;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        USpringArmComponent* FPMeshRootSpringArmComponent;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	USpringArmComponent* FPMeshRootSpringArmComponent;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        USkeletalMeshComponent* FPMesh;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	USceneComponent* OffsetRootSceneComponent;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        USpringArmComponent* FPCameraRootSpringArmComponent;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	USkeletalMeshComponent* FPMesh;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        USkeletalMeshComponent* CameraSkeletalMesh;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	USpringArmComponent* FPCameraRootSpringArmComponent;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        UCameraComponent* CameraComponent;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	USkeletalMeshComponent* CameraSkeletalMesh;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        USpringArmComponent* TPSpringArmComponent;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	UCameraComponent* CameraComponent;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        UHealthComponent* HealthComponent;
 
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	USpringArmComponent* TPSpringArmComponent;
-
-	UPROPERTY(BlueprintReadWrite, Category = "Shooter Character|Components")
-	UHealthComponent* HealthComponent;
-	
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Shooter Character|Components")
-	UInventoryComponent* InventoryComponent;
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+        UInventoryComponent* InventoryComponent;
 
 
 protected:

--- a/Source/Shooter/Public/Player/ShooterCharacter.h
+++ b/Source/Shooter/Public/Player/ShooterCharacter.h
@@ -26,37 +26,46 @@ class UAnimMontage;
 class UHealthComponent;
 
 UCLASS()
+/** Main player character class. Handles first/third person switching and weapon logic. */
 class SHOOTER_API AShooterCharacter : public ACharacter, public IAmmoProvider
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
 	AShooterCharacter();
 
 protected:
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        USpringArmComponent* FPMeshRootSpringArmComponent;
+       /** Spring arm used to position the first person mesh */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       USpringArmComponent* FPMeshRootSpringArmComponent;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        USkeletalMeshComponent* FPMesh;
+       /** First person body mesh */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       USkeletalMeshComponent* FPMesh;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        USpringArmComponent* FPCameraRootSpringArmComponent;
+       /** Spring arm used for the first person camera */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       USpringArmComponent* FPCameraRootSpringArmComponent;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        USkeletalMeshComponent* CameraSkeletalMesh;
+       /** Mesh used to attach the camera for animations */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       USkeletalMeshComponent* CameraSkeletalMesh;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        UCameraComponent* CameraComponent;
+       /** Player camera component */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       UCameraComponent* CameraComponent;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        USpringArmComponent* TPSpringArmComponent;
+       /** Third person camera spring arm */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       USpringArmComponent* TPSpringArmComponent;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        UHealthComponent* HealthComponent;
+       /** Manages health and damage */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       UHealthComponent* HealthComponent;
 
-        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
-        UInventoryComponent* InventoryComponent;
+       /** Handles weapons and ammo */
+       UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Shooter Character|Components")
+       UInventoryComponent* InventoryComponent;
 
 
 protected:
@@ -69,8 +78,9 @@ protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Shooter Character|Animations")
 	UAnimMontage* EquipMontage;
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Shooter Character")
-	EPlayerViewMode ViewMode;
+       /** Current camera mode */
+       UPROPERTY(ReplicatedUsing = OnRep_ViewMode, EditDefaultsOnly, BlueprintReadOnly, Category = "Shooter Character")
+       EPlayerViewMode ViewMode;
 	
 
 private:
@@ -116,11 +126,21 @@ public:
 
 	virtual int32 RequestAmmo_Implementation(FGameplayTag AmmoType, int32 RequestedAmount) override;
 
-	void SetPlayerViewMode(EPlayerViewMode NewViewMode);
+       /** Requests a view mode change. Will be replicated to all clients. */
+       void SetPlayerViewMode(EPlayerViewMode NewViewMode);
 
 private:
-	void AttachWeaponToMesh();
-	void PlayEquipMontage(bool bReverse);
+       /** Applies the current view mode locally */
+       void ApplyViewMode();
+
+       UFUNCTION(Server, Reliable)
+       void ServerSetPlayerViewMode(EPlayerViewMode NewViewMode);
+
+       UFUNCTION()
+       void OnRep_ViewMode();
+
+       void AttachWeaponToMesh();
+       void PlayEquipMontage(bool bReverse);
 
 	UFUNCTION()
 	void OnRep_WeaponActor();


### PR DESCRIPTION
## Summary
- remove ParkourMovementComponent from ShooterCharacter header and constructor

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a03e8afec83229cf3d4b859834dcd